### PR TITLE
No Granite No Install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,16 @@ include (ValaPrecompile)
 add_definitions (-DGETTEXT_PACKAGE="translator")
 
 find_package(PkgConfig)
-pkg_check_modules(DEPS REQUIRED gtk+-3.0 libsoup-2.4 gee-0.8 gio-2.0 granite gthread-2.0 json-glib-1.0)
+pkg_check_modules(DEPS REQUIRED gtk+-3.0 libsoup-2.4 gee-0.8 gio-2.0 gthread-2.0 json-glib-1.0)
 add_definitions(${DEPS_CFLAGS})
+add_definitions(-g)
 link_libraries(${DEPS_LIBRARIES})
 link_directories(${DEPS_LIBRARY_DIRS})
+
+configure_file (src/Main.vala.in src/Main.vala)
+configure_file (src/Settings.vala.in src/Settings.vala)
+configure_file (src/GlobalSettings.vala.in src/GlobalSettings.vala)
+execute_process (COMMAND glib-compile-schemas data)
 
 vala_precompile(VALA_C ${EXEC_NAME}
     src/Main.vala
@@ -40,13 +46,15 @@ vala_precompile(VALA_C ${EXEC_NAME}
     src/TranslatorService.vala
     src/DictionaryService.vala
     src/WebJsonClient.vala
+    src/Settings.vala
 PACKAGES
     gtk+-3.0
-    granite
+    gee-0.8
     libsoup-2.4
     json-glib-1.0
 OPTIONS
     --thread
+    --target-glib 2.38
 )
 
 add_executable(${EXEC_NAME} ${VALA_C})

--- a/src/GlobalSettings.vala.in
+++ b/src/GlobalSettings.vala.in
@@ -6,7 +6,7 @@ public class LangInfo : Object {
 public class GlobalSettings : Object {
     public static int PROXY_MODE_NONE = 0;
     public static int SERVER_RESPOND_TIMEOUT = 10;
-    private string TRANSLATOR_PATH = "/usr/share/translator";
+    private string TRANSLATOR_PATH = "@CMAKE_INSTALL_PREFIX@";
     private string _sourceStartLang = "en";
     private string _destStartLang = "ru";
     private LangInfo[] _langs;
@@ -14,7 +14,7 @@ public class GlobalSettings : Object {
     private Settings _settings;
 
     private GlobalSettings() {
-      _settings = new Settings ("skyprojects.eos.translator");
+      _settings = get_settings ("skyprojects.eos.translator");
     }
 
     public static GlobalSettings instance() {
@@ -52,18 +52,19 @@ public class GlobalSettings : Object {
     }
 
     public static Soup.URI getProxyUri() {
-        var settings = new Settings("org.gnome.system.proxy");
+        var settings = get_settings("org.gnome.system.proxy");
         var mode = settings.get_enum("mode");
         if (mode == PROXY_MODE_NONE) {
             return null;
         }
 
-        settings = new Settings("org.gnome.system.proxy.http");
+        settings = get_settings("org.gnome.system.proxy.http");
         var host = settings.get_string("host");
         var port = settings.get_int("port");
         var proxyUri = new Soup.URI(@"http://$host:$port");
         return proxyUri;
     }
+
 
     public LangInfo[] getLangs() {
         if (_langs != null) return _langs;
@@ -109,11 +110,12 @@ public class GlobalSettings : Object {
         return _langs;
     }
 
+
     public int getLangIndex(string langId) {
       var lngs = getLangs();
       for (var i=0; i < lngs.length; i++) {
         var l = lngs[i];
-        if (l.id == langId) {          
+        if (l.id == langId) {
           return i;
         }
       }

--- a/src/Main.vala.in
+++ b/src/Main.vala.in
@@ -15,7 +15,7 @@ public class Main : Object {
         opt_context.add_main_entries (options, null);
         opt_context.parse (ref args);
         var global = GlobalSettings.instance();
-        var settings = new Settings ("skyprojects.eos.translator");
+        var settings = get_settings ("skyprojects.eos.translator");
 
         var sourceLang = global.LoadSourceLang();
         var destLang = global.LoadDestLang();
@@ -34,6 +34,7 @@ public class Main : Object {
 
     Gtk.init (ref args);
     var app = new TranslateApplication();
+    Gtk.IconTheme.get_default().add_resource_path("@CMAKE_INSTALL_PREFIX@");
     return app.run (null);
   }
 }

--- a/src/Settings.vala.in
+++ b/src/Settings.vala.in
@@ -1,0 +1,75 @@
+/* Settings.vala
+ *
+ * Copyright (C) 2009 - 2016 Jerry Casiano
+ *
+ * This file is part of Translate.
+ *
+ * Translate is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Translate is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Translate.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author:
+ *        Jerry Casiano <JerryCasiano@gmail.com>
+*/
+
+const string [] POSSIBLE_SCHEMA_DIRS = {
+    "@CMAKE_INSTALL_PREFIX@/share/glib-2.0/schemas",
+    "@PROJECT_SOURCE_DIR@/data"
+};
+
+public Settings? get_settings (string schema_id) {
+
+    SettingsSchema? schema;
+    SettingsSchemaSource schema_source = SettingsSchemaSource.get_default();
+
+    schema = schema_source.lookup(schema_id, true);
+
+    if (schema == null) {
+        debug("No valid schema in default source. Checking for fallbacks");
+        var possible_schema_dirs = new Array <string> ();
+        string user_data_dir = Environment.get_user_data_dir();
+        string user_schema_dir = Path.build_filename(user_data_dir, "glib-2.0", "schemas");
+        possible_schema_dirs.append_val(user_schema_dir);
+        foreach (var dir in POSSIBLE_SCHEMA_DIRS)
+            possible_schema_dirs.append_val(dir);
+
+        for (int i = 0; i < possible_schema_dirs.length; i++) {
+            string dir = possible_schema_dirs.index(i);
+
+            {
+                File d = File.new_for_path(dir);
+                if (!d.query_exists())
+                    continue;
+            }
+
+            try {
+                debug("Checking for schema in %s", dir);
+                schema_source = new SettingsSchemaSource.from_directory(dir, null, false);
+            } catch (Error e) {
+                debug("Failed to create schema source for %s : %s", dir, e.message);
+                continue;
+            }
+            schema = schema_source.lookup(schema_id, true);
+            if (schema != null) {
+                debug("Loading schema with id %s from %s", schema_id, dir);
+                break;
+            }
+        }
+    }
+
+    if (schema == null) {
+        critical("Failed to find valid settings schema! Unable to store settings.");
+        return null;
+    }
+
+    return new Settings.full(schema, null, null);
+}

--- a/src/TranslatorApplication.vala
+++ b/src/TranslatorApplication.vala
@@ -1,4 +1,4 @@
-internal class TranslateApplication : Granite.Application {
+internal class TranslateApplication : Gtk.Application {
     public TranslateWindow mainWindow;
 
     public TranslateApplication() {
@@ -12,6 +12,5 @@ internal class TranslateApplication : Granite.Application {
         }
 
         this.mainWindow.show_all();
-        Gtk.main ();
     }
 }

--- a/src/TranslatorWindow.vala
+++ b/src/TranslatorWindow.vala
@@ -243,13 +243,6 @@ public class TranslateWindow : Gtk.ApplicationWindow {
 
         HideDictionary();
 
-        var style = @"
-                .dark-separator {
-                    color: #888;
-                }
-                ";
-        Granite.Widgets.Utils.set_theming_for_screen (this.get_screen (), style, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
         this.destroy.connect(OnWindowDestroy);
     }
 
@@ -452,6 +445,6 @@ public class TranslateWindow : Gtk.ApplicationWindow {
       var global = GlobalSettings.instance();
       global.SaveSourceLang(leftLang);
       global.SaveDestLang(rightLang);
-      Gtk.main_quit ();
+      base.destroy();
     }
 }


### PR DESCRIPTION
- Remove libgranite dependency
- Allow running from build directory

This probably should have been two separate requests, since you may want the Settings changes while keeping libgranite, however, since libgranite is hardly even used, it's a pointless dep anyway. 

You can always just copy that one function into the project instead of requiring libgranite.

Figured I would push these changes back before my branch deviates to far to be useful.
Having a little fun with it for now.
